### PR TITLE
Wrap context menu items into sub popup

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,12 +1,18 @@
 [
-  { "caption": "-"                                                                        },
-  { "command": "align_by", "args": { "by": "dialog"       }, "caption":"Align by..."      }, 
-  { "command": "align_by", "args": { "by": "equals"       }, "caption":"Align by ="       }, 
-  { "command": "align_by", "args": { "by": "equalsequals" }, "caption":"Align by =="      }, 
-  { "command": "align_by", "args": { "by": "m"            }, "caption":"Align by m_"      }, 
-  { "command": "align_by", "args": { "by": "quote"        }, "caption":"Align by \""      }, 
-  { "command": "align_by", "args": { "by": "period"       }, "caption":"Align by ."       }, 
-  { "command": "align_by", "args": { "by": "space"        }, "caption":"Align by space"   },
-  { "command": "align_by", "args": { "by": "caret"        }, "caption":"Align from caret" },
-  { "command": "align_by", "args": { "by": "key"          }, "caption":"Align by key"     }
+  {
+    "id": "code_align",
+    "caption": "Align by",
+    "children": [
+      { "caption": "-"                                                                        },
+      { "command": "align_by", "args": { "by": "dialog"       }, "caption":"Align by..."      },
+      { "command": "align_by", "args": { "by": "equals"       }, "caption":"Align by ="       },
+      { "command": "align_by", "args": { "by": "equalsequals" }, "caption":"Align by =="      },
+      { "command": "align_by", "args": { "by": "m"            }, "caption":"Align by m_"      },
+      { "command": "align_by", "args": { "by": "quote"        }, "caption":"Align by \""      },
+      { "command": "align_by", "args": { "by": "period"       }, "caption":"Align by ."       },
+      { "command": "align_by", "args": { "by": "space"        }, "caption":"Align by space"   },
+      { "command": "align_by", "args": { "by": "caret"        }, "caption":"Align from caret" },
+      { "command": "align_by", "args": { "by": "key"          }, "caption":"Align by key"     }
+    ]
+  }
 ]


### PR DESCRIPTION
The .sublime-menu provides really many items which results in the the context menu being really huge.

I just wrapped them into a parent menu which is way better, imo.
